### PR TITLE
Fixed <if> logic so that storeable actions are successfully cached.

### DIFF
--- a/src/aura/ETLC_ApexBridge/ETLC_ApexBridgeHelper.js
+++ b/src/aura/ETLC_ApexBridge/ETLC_ApexBridgeHelper.js
@@ -52,9 +52,6 @@
                 request: request,
                 action: action
             });
-            if(forceRefresh) {
-            	action.setStorable({"ignoreExisting": "true"});
-            }
         }
         
         startTime = new Date();

--- a/src/aura/ETLC_ApexBridge/ETLC_ApexBridgeHelper.js
+++ b/src/aura/ETLC_ApexBridge/ETLC_ApexBridgeHelper.js
@@ -44,14 +44,17 @@
         // Force refresh?
         if (forceRefresh) {
             action.setStorable({"ignoreExisting": "true"});
-        } else if (component.get("v.debugClient")) {
+        } else {
+            action.setStorable();
+        }
+        if (component.get("v.debugClient")) {
             console.log('Getting ready to call Apex. ', {
                 request: request,
                 action: action
             });
-            action.setStorable({"ignoreExisting": "true"});
-        } else {
-            action.setStorable();
+            if(forceRefresh) {
+            	action.setStorable({"ignoreExisting": "true"});
+            }
         }
         
         startTime = new Date();


### PR DESCRIPTION
I found an issue in this block of code where the <if> logic was preventing actions from being successfully cached when the "forceRefresh" boolean was set to false. I believe it was because of line 47 introducing an <else if> on debugClient that did not correspond to the same boolean on line 45. Therefore, I separated the boolean check for "debugClient" into a separate <if> block so that it would be independent of the "forceRefresh" check and that resolved the issue. Please let me know if there is any other information I can provide.